### PR TITLE
Fix output

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,9 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    distDir: 'out', compress: false, productionBrowserSourceMaps: true,
+    distDir: 'out',
+    output: 'export',
+    compress: false,
     // ...
     /**
      * @param {import('webpack').Configuration} webpackConfig
@@ -14,8 +16,8 @@ const nextConfig = {
             optimization: {
                 minimize: false,
             },
-        };
+        }
     },
-};
+}
 
-module.exports = nextConfig;
+module.exports = nextConfig


### PR DESCRIPTION
## Summary by Sourcery

Configures the Next.js application to export a static site instead of a server-rendered one by setting the 'output' option to 'export'. Disables minification during the build process.

Enhancements:
- Disables minification during the build process.
- Configures the Next.js application to export a static site.